### PR TITLE
Minor bugs and compatibility with Windows

### DIFF
--- a/jarvis/prediction/jarvis3D.py
+++ b/jarvis/prediction/jarvis3D.py
@@ -186,4 +186,5 @@ class JarvisPredictor3D(nn.Module):
                         distortionCoefficients.unsqueeze(0))
         else:
             points3D = None
+            confidences = None
         return points3D, confidences

--- a/jarvis/visualization/create_videos3D.py
+++ b/jarvis/visualization/create_videos3D.py
@@ -128,7 +128,7 @@ def create_video_writer_and_reader(params, reproTool, video_paths,
         if make_video_index[i]:
             frameRate = cap.get(cv2.CAP_PROP_FPS)
             outs.append(cv2.VideoWriter(os.path.join(params.output_dir,
-                        path.split('/')[-1].split(".")[0] + ".mp4"),
+                        path.split(os.sep)[-1].split(".")[0] + ".mp4"),
                         cv2.VideoWriter_fourcc('m', 'p', '4', 'v'),
                         frameRate,
                         (img_size[0],img_size[1])))


### PR DESCRIPTION
Hi,
I was testing your tool - thanks for the amazing work! - and I encountered few problems within Windows.

First, the prediction failed for me in some cases: I guess it was due to the function jarvis3D.py not returning a confidence value when no prediction was made.

Second, I got problems when creating the videos for visualization due to the different separators in Windows and Unix: using os.sep should solve the problem!

Thank you!
Michael